### PR TITLE
Migrate Java arrays to JDK 11

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Set version env variable
         run: echo ::set-env name=VERSION::$((grep -w "version" | cut -d= -f2) < gradle.properties | cut -d- -f1)
       - name : Pre release depenency version update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Find API docs for the Java Arrays library [here](https://ballerina.io/swan-lake/
 
 ### Setting Up the Prerequisites
 
-* Download and install Java SE Development Kit (JDK) version 8 (from one of the following locations).
+* Download and install Java SE Development Kit (JDK) version 11 (from one of the following locations).
 
-   * [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
+   * [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
    
-   * [OpenJDK](http://openjdk.java.net/install/index.html)
+   * [OpenJDK](https://adoptopenjdk.net/)
    
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
@@ -30,29 +30,15 @@ Execute the commands below to build from source.
         
         ./gradlew clean build
 
-2. To run the integration tests:
+1. To run the integration tests:
 
         ./gradlew clean test
 
-3. To build the module without the tests:
+1. To build the module without the tests:
 
         ./gradlew clean build -x test
 
-4. To run only specific tests:
-
-        ./gradlew clean build -Pgroups=<Comma separated groups/test cases>
-
-   **Tip:** The following groups of test cases are available.<br>
-   Groups | Test Cases
-   ---| ---
-   connection | connection
-   pool | pool
-   transaction | transaction
-   execute | execute-basic <br> execute-params
-   batch-execute | batch-execute 
-   query | query-simple-params<br>query-numeric-params<br>query-complex-params
-
-4. To debug the tests:
+1. To debug the tests:
 
         ./gradlew clean build -Pdebug=<port>
 

--- a/java.arrays-test-utils/build.gradle
+++ b/java.arrays-test-utils/build.gradle
@@ -25,3 +25,12 @@ dependencies {
     compile group: 'org.ballerinalang', name: 'ballerina-core', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
 }
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/java.arrays-test-utils/src/main/java/module-info.java
+++ b/java.arrays-test-utils/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module java.arrays.java.arrays.test.utils.main {
+    requires io.ballerina.jvm;
+    exports org.ballerinalang.stdlib.java.arrays.testutils;
+}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/module-ballerina-java.arrays/issues/13

## Approach
- Upgrade action JDK
- Add `compileJava` task
- Add `module-info.java` file
- Update README

## Test environment
- macOS
- SLP5
- Java 11